### PR TITLE
Fix the Arduino Lint check

### DIFF
--- a/.github/workflows/Arduino-Lint-Check.yml
+++ b/.github/workflows/Arduino-Lint-Check.yml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: arduino/arduino-lint-action@v2
         with:
-          library-manager: update
+          library-manager: submit
           compliance: strict
           project-type: all

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=
 category=Device Control
 url=https://github.com/m5stack/StackChan-BSP
 architectures=esp32
-includes=src,src/utils
+includes=M5StackChan.h
 depends=M5Unified,IRremoteESP8266,M5Unit-NFC

--- a/src/StackChan-BSP.h
+++ b/src/StackChan-BSP.h
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2026 M5Stack Technology CO LTD
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+// Header named after the library (Arduino Library Specification); the API lives in M5StackChan.h
+#include "M5StackChan.h"


### PR DESCRIPTION
The `Arduino Lint Check` workflow has failed on every run of `main` since April (it is not caused by any particular PR). Running `arduino-lint --compliance strict --library-manager update` locally reproduces the CI result: 3 errors, 1 warning.

## What fails and why

| Rule | Message | Cause |
|---|---|---|
| LP052 (error) | `library.properties includes field item(s) src, src/utils not found in library` | `includes=` must list header files, not directories |
| LS008 (warning) | `No header file found matching library name (StackChan-BSP.h)` | best practice: primary header named after the library |
| LP018 (error) | `Library name StackChan-BSP not found in the Library Manager index` | the library is not registered in the Arduino Library Manager, and `library-manager: update` in the workflow asks arduino-lint to enforce the registration rules |
| LP042 (error) | `Unable to load the library.properties url field: ... unexpected EOF` | transient network error on the runner; the URL is valid and this does not reproduce locally |

## Changes

1. `library.properties`: `includes=M5StackChan.h`, and add `src/StackChan-BSP.h` as the primary header (it only includes `M5StackChan.h`, so existing sketches are unaffected). This clears LP052 and LS008.
2. Workflow: `library-manager: submit`. LP018 cannot be fixed from the repository content; it only goes away once the library has been accepted into the Library Manager index. `submit` is arduino-lint's mode for a library that is not in the index yet: it keeps the pre-registration checks active without requiring the name to be present. Switch to `update` once the library has been accepted — feel free to drop this commit if you prefer to keep the red check as a reminder.

With both commits `arduino-lint --compliance strict --library-manager submit` reports no errors or warnings for the library and all examples.
