### PR TITLE
Add a workflow that compiles every example

### DIFF
--- a/.github/workflows/Arduino-Build-Check.yml
+++ b/.github/workflows/Arduino-Build-Check.yml
@@ -1,0 +1,82 @@
+name: Arduino Build Check
+
+on:
+  push:
+    paths:
+      - '**.ino'
+      - '**.cpp'
+      - '**.hpp'
+      - '**.h'
+      - '**.c'
+      - 'library.properties'
+      - '.github/workflows/Arduino-Build-Check.yml'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: examples (${{ matrix.board }}, M5Unified ${{ matrix.m5unified }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Latest arduino-esp32 with the released libraries (what a user gets from the Library Manager)
+          - board: esp32:esp32:esp32s3
+            esp32_version: 3.3.11
+            m5unified: release
+          # Same core with the development branches of M5Unified / M5GFX: catches API changes before they are released
+          - board: esp32:esp32:esp32s3
+            esp32_version: 3.3.11
+            m5unified: develop
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install arduino-cli
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh -s 1.1.1
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+
+      - name: Install board package
+        run: |
+          arduino-cli config init
+          arduino-cli config add board_manager.additional_urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          arduino-cli core update-index
+          CORE=$(echo "${{ matrix.board }}" | cut -d: -f1,2)
+          arduino-cli core install "${CORE}@${{ matrix.esp32_version }}"
+
+      - name: Install libraries
+        run: |
+          mkdir -p "$HOME/Arduino/libraries"
+          ln -s "$GITHUB_WORKSPACE" "$HOME/Arduino/libraries/StackChan-BSP"
+          arduino-cli lib update-index
+          # dependencies of library.properties; M5Unit-NFC pulls in M5UnitUnified / M5HAL / M5Utility
+          arduino-cli lib install IRremoteESP8266 M5Unit-NFC
+          if [ "${{ matrix.m5unified }}" = "develop" ]; then
+            git clone --depth 1 --branch develop https://github.com/m5stack/M5GFX.git "$HOME/Arduino/libraries/M5GFX"
+            git clone --depth 1 --branch develop https://github.com/m5stack/M5Unified.git "$HOME/Arduino/libraries/M5Unified"
+          else
+            arduino-cli lib install M5Unified
+          fi
+          arduino-cli lib list
+
+      - name: Build examples
+        run: |
+          status=0
+          for ino in $(find examples -name '*.ino' | sort); do
+            echo "::group::$ino"
+            if arduino-cli compile --fqbn "${{ matrix.board }}" --warnings default "$ino"; then
+              echo "OK   $ino"
+            else
+              echo "FAIL $ino"
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $status


### PR DESCRIPTION
Adds a workflow that compiles every sketch under `examples/` with arduino-cli, so that a build break like m5stack/StackChan-BSP#12 (the library stopped compiling against a new M5Unified release) is caught by CI instead of by users.

## What it does

- `ubuntu-latest`, arduino-cli 1.1.1, latest arduino-esp32 (3.3.11) from the Espressif board index, `esp32:esp32:esp32s3` (the StackChan core is an ESP32-S3).
- Two jobs (`fail-fast: false`):
  - **release** — M5Unified / M5GFX from the Library Manager, i.e. what a user gets today.
  - **develop** — M5Unified / M5GFX cloned from their `develop` branches, so an interface change in those libraries shows up here before it is released.
- The other dependencies (`IRremoteESP8266`, `M5Unit-NFC` and what it pulls in) come from the Library Manager.
- All 10 examples are compiled in one job; a failure does not stop the remaining sketches, the job fails at the end if any of them failed. Each sketch is a collapsible group in the log.

Runs on push (source / `library.properties` / the workflow itself), on pull requests, and manually.

## Verification

Run on my fork against the current `main`: both jobs green, 10/10 sketches each (about 25 minutes per job, the two run in parallel).
